### PR TITLE
Adds types export to pkg.json#exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,17 +19,20 @@
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
-      "default": "./dist/index.js"
+      "default": "./dist/index.js",
+      "types": "./index.d.ts"
     },
     "./dates": {
       "import": "./dates/index.mjs",
       "require": "./dates/index.js",
-      "default": "./dates/index.js"
+      "default": "./dates/index.js",
+      "types": "./dates/index.d.ts"
     },
     "./dates/utc": {
       "import": "./dates/utc/index.mjs",
       "require": "./dates/utc/index.js",
-      "default": "./dates/utc/index.js"
+      "default": "./dates/utc/index.js",
+      "types": "./dates/utc/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Types fail to resolve on node20/vite#vanilla-ts due to not being included in the exports field.

This PR... adds type exports to the package.json exports field.

Thanks for the package!

Before patch:

<img width="1167" alt="image" src="https://github.com/shuckster/match-iz/assets/16165237/9040e894-4eff-42a0-9c66-3535a784593d">


Post patch:

<img width="1026" alt="image" src="https://github.com/shuckster/match-iz/assets/16165237/50f61e74-99b4-434b-8342-a13faae89df7">
